### PR TITLE
Add buildvms, listvms, vmshell commands

### DIFF
--- a/run.py
+++ b/run.py
@@ -597,7 +597,6 @@ def write_compose(
                                 "incus": {
                                     "dns": [config.dns],
                                     "build": "./incus",
-                                    "depends_on": ["router"],
                                     "networks": ["externalnet"],
                                     **(
                                         {"restart": "unless-stopped"}
@@ -1039,6 +1038,87 @@ def router_generate_configs(config: Config, down_after_gen: bool = True):
     return False
 
 
+def buildvms(config):
+    vm_dir_hash = dir_sha_hash("./vm")
+    info = get_deploy_info()
+    old_vm_dir_hash = info.get("vm_dir_hash", "")
+    was_built_with = info.get("vm_mode_build", False)
+    vm_router_hash = info.get("vm_router_hash", None)
+    current_router_hash = server_config_hash(config)
+    if config.vm_mode == "privileged" or config.vm_mode == "sysbox":
+        if (
+            not prebuilt_exists()
+            or vm_dir_hash != old_vm_dir_hash
+            or was_built_with != config.vm_mode
+        ):
+            puts("Need to build the team VM image", color=colors.yellow)
+            clear_data_only(
+                remove_prebuilded_container=True,
+                remove_prebuilt_image=True,
+                remove_prebuilder_image=True,
+                remove_incus_data=True,
+            )
+            puts("Building the prebuilder image", color=colors.yellow)
+            if not build_prebuilder():
+                puts("Error building prebuilder image", color=colors.red)
+                exit(1)
+            puts(
+                "Executing prebuilder to create VMs' base image",
+                color=colors.yellow,
+            )
+            if not build_prebuilt(config.vm_mode == "privileged"):
+                puts("Error building prebuilt image", color=colors.red)
+                exit(1)
+            puts(
+                "Saving base VM container as image to be used to build the CTF services\n(this action can take a while and produces no output)",
+                color=colors.yellow,
+            )
+            if not commit_prebuilt():
+                puts("Error commiting prebuilt image", color=colors.red)
+                exit(1)
+            puts("Clear unused images", color=colors.yellow)
+            remove_prebuilded()
+    elif config.vm_mode == "none":
+        puts(
+            "VM 'none' mode selected, skipping VM image build",
+            color=colors.yellow,
+        )
+    elif config.vm_mode == "incus":
+        if (
+            not incus_data_exists()
+            or vm_dir_hash != old_vm_dir_hash
+            or was_built_with != config.vm_mode
+            or vm_router_hash != current_router_hash
+        ):
+            write_compose(config, incus_unless_stopped=False)
+            puts("Need to build the incus VMs", color=colors.yellow)
+            clear_data_only(
+                remove_prebuilded_container=True,
+                remove_prebuilt_image=True,
+                remove_prebuilder_image=True,
+                remove_incus_data=True,
+            )
+            puts("Building the incus VMs", color=colors.yellow)
+            composecmd(
+                "up incus --build --remove-orphans --exit-code-from incus",
+                g.composefile,
+            )
+            write_compose(config)
+        else:
+            puts(
+                "Incus VMs already exists, skipping build",
+                color=colors.yellow,
+            )
+    else:
+        invalid_vm_mode()
+    set_deploy_info(
+        {
+            "vm_dir_hash": vm_dir_hash,
+            "vm_mode_build": config.vm_mode,
+            "vm_router_hash": current_router_hash,
+        }
+    )
+
 def main():
     if args.command == "start":
         if args.config_only:
@@ -1085,6 +1165,16 @@ def main():
                     config = read_config()
                     write_compose(config)
                     router_generate_configs()
+            case "buildvms":
+                if not config_exists():
+                    puts(
+                        "Config file not found! please create config.json first",
+                        color=colors.red,
+                    )
+                else:
+                    config = read_config()
+                if len(config.teams) > 0:
+                    buildvms(config)
             case "start":
                 if check_already_running():
                     puts(f"{g.name} is already running!", color=colors.yellow)
@@ -1126,85 +1216,7 @@ def main():
                     router_generate_configs(config, down_after_gen=False)
 
                 if len(config.teams) > 0:
-                    vm_dir_hash = dir_sha_hash("./vm")
-                    info = get_deploy_info()
-                    old_vm_dir_hash = info.get("vm_dir_hash", "")
-                    was_built_with = info.get("vm_mode_build", False)
-                    vm_router_hash = info.get("vm_router_hash", None)
-                    current_router_hash = server_config_hash(config)
-                    if config.vm_mode == "privileged" or config.vm_mode == "sysbox":
-                        if (
-                            not prebuilt_exists()
-                            or vm_dir_hash != old_vm_dir_hash
-                            or was_built_with != config.vm_mode
-                        ):
-                            puts("Need to build the team VM image", color=colors.yellow)
-                            clear_data_only(
-                                remove_prebuilded_container=True,
-                                remove_prebuilt_image=True,
-                                remove_prebuilder_image=True,
-                                remove_incus_data=True,
-                            )
-                            puts("Building the prebuilder image", color=colors.yellow)
-                            if not build_prebuilder():
-                                puts("Error building prebuilder image", color=colors.red)
-                                exit(1)
-                            puts(
-                                "Executing prebuilder to create VMs' base image",
-                                color=colors.yellow,
-                            )
-                            if not build_prebuilt(config.vm_mode == "privileged"):
-                                puts("Error building prebuilt image", color=colors.red)
-                                exit(1)
-                            puts(
-                                "Saving base VM container as image to be used to build the CTF services\n(this action can take a while and produces no output)",
-                                color=colors.yellow,
-                            )
-                            if not commit_prebuilt():
-                                puts("Error commiting prebuilt image", color=colors.red)
-                                exit(1)
-                            puts("Clear unused images", color=colors.yellow)
-                            remove_prebuilded()
-                    elif config.vm_mode == "none":
-                        puts(
-                            "VM 'none' mode selected, skipping VM image build",
-                            color=colors.yellow,
-                        )
-                    elif config.vm_mode == "incus":
-                        if (
-                            not incus_data_exists()
-                            or vm_dir_hash != old_vm_dir_hash
-                            or was_built_with != config.vm_mode
-                            or vm_router_hash != current_router_hash
-                        ):
-                            write_compose(config, incus_unless_stopped=False)
-                            puts("Need to build the incus VMs", color=colors.yellow)
-                            clear_data_only(
-                                remove_prebuilded_container=True,
-                                remove_prebuilt_image=True,
-                                remove_prebuilder_image=True,
-                                remove_incus_data=True,
-                            )
-                            puts("Building the incus VMs", color=colors.yellow)
-                            composecmd(
-                                "up incus --build --remove-orphans --exit-code-from incus",
-                                g.composefile,
-                            )
-                            write_compose(config)
-                        else:
-                            puts(
-                                "Incus VMs already exists, skipping build",
-                                color=colors.yellow,
-                            )
-                    else:
-                        invalid_vm_mode()
-                    set_deploy_info(
-                        {
-                            "vm_dir_hash": vm_dir_hash,
-                            "vm_mode_build": config.vm_mode,
-                            "vm_router_hash": current_router_hash,
-                        }
-                    )
+                    buildvms(config)
                 puts("Running 'docker compose up -d --build\n", color=colors.green)
                 composecmd("up -d --build --remove-orphans", g.composefile)
             case "compose":

--- a/run.py
+++ b/run.py
@@ -278,6 +278,21 @@ def gen_args(args_to_parse: list[str] | None = None):
         "--gameserver-data", "-G", action="store_true", help="Clear gameserver data"
     )
 
+    subcommands.add_parser("listvms", help="List team VMs")
+
+    parser_vmshell = subcommands.add_parser("vmshell", help="Open a shell in the specified team VM")
+    parser_vmshell.add_argument(
+        "team_id",
+        type=int,
+        help="ID of the team whose VM to access (use listvms to see the IDs)",
+    )
+    parser_vmshell.add_argument(
+        "vmshell_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments to pass to exec command for team vms",
+        default=[],
+    )
+
     # Status Command
     subcommands.add_parser("status", help="Show status")
 
@@ -1203,6 +1218,39 @@ def main():
                     compose_cmd = " ".join(args.compose_args)
                     puts(f"Running 'docker compose {compose_cmd}'\n", color=colors.green)
                     composecmd(compose_cmd, g.composefile)
+            case "vmshell":
+                if not config_exists():
+                    puts(
+                        f"Config file not found! please run {sys.argv[0]} start",
+                        color=colors.red,
+                    )
+                elif check_already_running():
+                    config = read_config()
+                    if config.vm_mode == "privileged" or config.vm_mode == "sysbox":
+                        compose_cmd = f"exec team{args.team_id}"
+                    elif config.vm_mode == "incus":
+                        compose_cmd = f"exec incus incus exec vm{args.team_id} --"
+                    elif config.vm_mode == "none":
+                        puts(
+                            "VM 'none' mode selected",
+                            color=colors.yellow,
+                        )
+
+                    if args.vmshell_args:
+                        compose_cmd += f" {' '.join(args.vmshell_args)}"
+                    else:
+                        compose_cmd += " /bin/bash"
+
+                    write_compose(config)
+                    puts(f"Running 'docker compose {compose_cmd}'\n", color=colors.green)
+                    composecmd(compose_cmd, g.composefile)
+                else:
+                    puts(
+                        f"{g.name} is not running!",
+                        color=colors.red,
+                        is_bold=True,
+                        flush=True,
+                    )
             case "restart":
                 if not config_exists():
                     puts(
@@ -1273,6 +1321,23 @@ def main():
             case "status":
                 if check_already_running():
                     puts(f"{g.name} is running!", color=colors.green)
+            case "listvms":
+                if not config_exists():
+                    puts(
+                        f"Config file not found! please run {sys.argv[0]} start",
+                        color=colors.red,
+                    )
+                config = read_config()
+                if config.vm_mode == "none":
+                    puts(
+                        "VM 'none' mode selected, no VMs to list",
+                        color=colors.yellow,
+                    )
+                    return
+                for team in config.teams:
+                    if team.nop:
+                        continue
+                    puts(f"Team {team.id} - {team.name}")
 
     if "logs" in args and args.logs:
         if config_exists():


### PR DESCRIPTION
- Add `buildvms` command to only build the team VMs without starting anything else (hopefully, not tested with sysbox/privileged)
  - Refactor the build code from the start command code to a separate `buildvms()` function
- Add `listvms` command to list the team IDs and their respective names
- Add `vmshell` command as a shortcut to `compose exec teamN`/`compose exec incus incus exec vmN`